### PR TITLE
Canvas: ModelとViewで分割

### DIFF
--- a/js/canvas-model.js
+++ b/js/canvas-model.js
@@ -10,10 +10,9 @@ function CanvasModel(element) {
     this.drawState = drawState;
   });
 
-  eventPublisher.subscribe(
-      "currentFrameId", (nextCurrentFrame) => {
-        eventPublisher.publish("imageData", this.getImageData());
-      });
+  eventPublisher.subscribe("currentFrameId", (nextCurrentFrame) => {
+    eventPublisher.publish("imageData", this.getImageData());
+  });
 
   // この imageDataというものだが、
   // Modelのように見せているが、実際は存在せず、

--- a/js/canvas-model.js
+++ b/js/canvas-model.js
@@ -1,0 +1,38 @@
+const eventPublisher = require("./publisher");
+
+// HTMLCanvasElementをラップし, canvasRenderingContext2Dに関する操作を提供する
+function CanvasModel(element, framesController) {
+  this.element = element;
+
+  this.context = this.element.getContext("2d");
+  this.drawState = "idling";
+  eventPublisher.subscribe("drawState", (drawState) => {
+    this.drawState = drawState;
+  });
+
+  eventPublisher.subscribe(
+      "currentFrameId", (nextCurrentFrame) => {
+    // 今のCanvasを今のFrameに書き込む
+    framesController.getCurrentFrame().imageData = this.getImageData();
+
+    // 次のFrameをCanvasに反映させる
+    let nextImageData =
+    framesController.getFrameById(nextCurrentFrame).imageData;
+    if (nextImageData !== null) {
+      this.setImageData(nextImageData);
+    }
+  });
+}
+
+CanvasModel.prototype.getImageData = function() {
+  return this.context.getImageData(0, 0,
+    this.element.width, this.element.height);
+};
+
+CanvasModel.prototype.setImageData = function(imageData) {
+  this.context.clearRect(0, 0,
+    this.element.width, this.element.height); // クリアする必要があるのか
+  this.context.putImageData(imageData, 0, 0);
+};
+
+module.exports = CanvasModel;

--- a/js/canvas-model.js
+++ b/js/canvas-model.js
@@ -12,8 +12,8 @@ function CanvasModel(element) {
 
   eventPublisher.subscribe(
       "currentFrameId", (nextCurrentFrame) => {
-    eventPublisher.publish("imageData", this.getImageData());
-  });
+        eventPublisher.publish("imageData", this.getImageData());
+      });
 
   // この imageDataというものだが、
   // Modelのように見せているが、実際は存在せず、

--- a/js/frames-controller.js
+++ b/js/frames-controller.js
@@ -26,8 +26,11 @@ FramesController.prototype.remove = function() {
 };
 
 FramesController.prototype.setCurrentFrame = function(frameId) {
+  var nextImageData;
+
   eventPublisher.publish("currentFrameId", frameId);
-  var nextImageData = this.getCurrentFrame().imageData;
+
+  nextImageData = this.getCurrentFrame().imageData;
   // 初めて作るFrame（nextImageDataがnull）の時は、
   // 前のFrameの内容をそのままコピーするため、imageDataをpublishする必要はない。
   if (nextImageData !== null) {

--- a/js/frames-controller.js
+++ b/js/frames-controller.js
@@ -4,6 +4,14 @@ const eventPublisher = require("./publisher");
 function FramesController() {
   this.frames = [];
   this.currentFrameId = 0;
+  eventPublisher.subscribe("currentFrameId", (frameId) => {
+    this.currentFrameId = frameId;
+  });
+
+  eventPublisher.subscribe("imageData", (imageData) => {
+    // この時の currentFrame は、変更される前を示す。
+    this.getCurrentFrame().imageData = imageData;
+  });
 }
 
 // パラメータ id : どこの後ろに追加するのか（今は実装していない）
@@ -18,8 +26,13 @@ FramesController.prototype.remove = function() {
 };
 
 FramesController.prototype.setCurrentFrame = function(frameId) {
-  this.currentFrameId = frameId;
   eventPublisher.publish("currentFrameId", frameId);
+  var nextImageData = this.getCurrentFrame().imageData;
+  // 初めて作るFrame（nextImageDataがnull）の時は、
+  // 前のFrameの内容をそのままコピーするため、imageDataをpublishする必要はない。
+  if (nextImageData !== null) {
+    eventPublisher.publish("imageData", nextImageData);
+  }
 };
 
 FramesController.prototype.getFrameById = function(frameId) {

--- a/js/main.js
+++ b/js/main.js
@@ -23,8 +23,7 @@ document.addEventListener("DOMContentLoaded", function() {
   framesController = new FramesController();
   framesController.append(firstFrameId);
 
-  canvasModel =
-    new CanvasModel(document.getElementById("canvas"), framesController);
+  canvasModel = new CanvasModel(document.getElementById("canvas"));
   paintManager = new PaintManager(document.getElementById("canvas"));
 
   viewManager = new ViewManager();

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,6 @@
 const FramesController = require("./frames-controller");
 const DrawingConfiguration = require("./drawing-configuration");
+const CanvasModel = require("./canvas-model");
 const ViewManager = require("./view-manager");
 const PaintManager = require("./paint-manager");
 
@@ -10,6 +11,7 @@ require("web-animations-js");
 
 let framesController;
 let drawingConfiguration;
+let canvasModel;
 let viewManager;
 let paintManager;
 
@@ -21,10 +23,9 @@ document.addEventListener("DOMContentLoaded", function() {
   framesController = new FramesController();
   framesController.append(firstFrameId);
 
-  paintManager = new PaintManager(
-    document.getElementById("canvas"),
-    drawingConfiguration,
-    framesController);
+  canvasModel =
+    new CanvasModel(document.getElementById("canvas"), framesController);
+  paintManager = new PaintManager(document.getElementById("canvas"));
 
   viewManager = new ViewManager();
 

--- a/js/paint-manager.js
+++ b/js/paint-manager.js
@@ -1,7 +1,7 @@
 const eventPublisher = require("./publisher");
 
 // HTMLCanvasElementをラップし, canvasRenderingContext2Dに関する操作を提供する
-function PaintManager(element, drawConfig, framesController) {
+function PaintManager(element) {
   this.element = element;
   this.element.width = window.innerWidth;
   this.element.height = window.innerHeight;
@@ -13,21 +13,16 @@ function PaintManager(element, drawConfig, framesController) {
     event => { this.mouseMoveCanvas(event); });
 
   this.context = this.element.getContext("2d");
-  this.drawState = "idling";
-  this.config = drawConfig;
 
-  eventPublisher.subscribe(
-      "currentFrameId", (nextCurrentFrame) => {
-    // 今のCanvasを今のFrameに書き込む
-        framesController.getCurrentFrame().imageData = this.getImageData();
+  this.color = "";
+  eventPublisher.subscribe("color", (color) => {
+    this.color = color;
+  });
 
-    // 次のFrameをCanvasに反映させる
-        let nextImageData =
-      framesController.getFrameById(nextCurrentFrame).imageData;
-        if (nextImageData !== null) {
-          this.setImageData(nextImageData);
-        }
-      });
+  this.lineWidth = 0;
+  eventPublisher.subscribe("lineWidth", (lineWidth) => {
+    this.lineWidth = lineWidth;
+  });
 }
 
 let isMouseDown = false;
@@ -35,28 +30,26 @@ let previousMousePosition;
 PaintManager.prototype.mouseDownCanvas = function(event) {
   isMouseDown = true;
   previousMousePosition = { x: event.clientX, y: event.clientY };
-  this.drawState = "drawing";
   eventPublisher.publish("drawState", "drawing");
 };
 PaintManager.prototype.mouseUpCanvas = function() {
   isMouseDown = false;
-  this.drawState = "idling";
   eventPublisher.publish("drawState", "idling");
 };
 PaintManager.prototype.mouseMoveCanvas = function(event) {
   if (isMouseDown) {
-    if (this.config.color === "white") {
+    if (this.color === "white") {
       this.eraseByLine(
         previousMousePosition,
         { x: event.clientX, y: event.clientY },
-        this.config.lineWidth
+        this.lineWidth
       );
     } else {
       this.drawLine(
         previousMousePosition,
         { x: event.clientX, y: event.clientY },
-        this.config.color,
-        this.config.lineWidth
+        this.color,
+        this.lineWidth
       );
     }
     previousMousePosition = { x: event.clientX, y: event.clientY };
@@ -91,17 +84,6 @@ PaintManager.prototype.eraseByLine = function(
   this.context.globalCompositeOperation = "destination-out";
   this.drawLine(startPosition, endPosition, "#000", lineWidth);
   this.context.globalCompositeOperation = "source-over";
-};
-
-PaintManager.prototype.getImageData = function() {
-  return this.context.getImageData(0, 0,
-    this.element.width, this.element.height);
-};
-
-PaintManager.prototype.setImageData = function(imageData) {
-  this.context.clearRect(0, 0,
-    this.element.width, this.element.height); // クリアする必要があるのか
-  this.context.putImageData(imageData, 0, 0);
 };
 
 module.exports = PaintManager;


### PR DESCRIPTION
Canvasを Model / View に分割するため、
canvas-model.jsとpaint-manager.jsに分けました。
canvas-model.js側では、set/get ImageData のみ（Modelに関わる部分）実装するようにしました。

@hrl7 さん、よろしくお願いします！

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/comozilla/parapara-canvas-editor/69)

<!-- Reviewable:end -->
